### PR TITLE
Renamed /var/docker to /var/discourse

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ hooks:
 Rebuild the container
 
 ```
-cd /var/docker
+cd /var/discourse
 git pull
 ./launcher rebuild app
 ```


### PR DESCRIPTION
related: https://meta.discourse.org/t/discourse-adplugin-error-occurred-with-asense-code/79501/2