### PR TITLE
FIX: resolve collision on ember's builtin w string function

### DIFF
--- a/assets/javascripts/discourse/components/google-dfp-ad.js.es6
+++ b/assets/javascripts/discourse/components/google-dfp-ad.js.es6
@@ -216,6 +216,8 @@ export default Ember.Component.extend({
   _initGoogleDFP: function() {
     if (!this.get('showAd')) { return; }
 
+    const ember_w_function = String.prototype.w;
+    String.prototype.w = null;
     var self = this;
     loadGoogle(this.siteSettings).then(function() {
       self.set('loadedGoogletag', true);
@@ -229,6 +231,8 @@ export default Ember.Component.extend({
           window.googletag.pubads().refresh([slot.ad]);
         }
       });
+    }).finally(function() {
+      String.prototype.w = ember_w_function;
     });
   }.on('didInsertElement'),
 


### PR DESCRIPTION
Ember adds a w function in the string prototype that is breaking Discourse sites from loading up the add plugin, which expects w to be null for strings in minified code.

https://emberjs.com/api/ember/3.1/classes/String/methods/w?anchor=w