### PR TITLE
Remove need to only allow UUID as CodeFund Property ID

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -346,7 +346,6 @@ codefund_plugin:
   codefund_property_id:
     client: true
     default: ''
-    regex: '^[\d]*$'
   codefund_advertiser_label:
     client: true
     default: 'Advertiser'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -346,7 +346,7 @@ codefund_plugin:
   codefund_property_id:
     client: true
     default: ''
-    regex: '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+    regex: '^[\d]*$'
   codefund_advertiser_label:
     client: true
     default: 'Advertiser'


### PR DESCRIPTION
In January, we began supporting integer-based property IDs. We still support the legacy UUID's as well.

This PR will allow for both.