### PR TITLE
Carbon Ads Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This is the official Discourse advertising plugin.  It allows advertisements to 
 * [Google Double Click for Publishers](https://www.google.com/dfp)
 * [Amazon Affiliates](http://affiliate-program.amazon.com) - Banner and Product Link Ads
 * [CodeFund](https://codefund.io) - Ethical Ad Platform for Developers
+* [Carbon Ads](https://www.carbonads.net/)
 
 
 ## Quick Start in 3 Steps
@@ -65,6 +66,7 @@ There are 2 easy steps for configuring your Discourse settings to enable adverti
 <li>Adsense - if using Adsense as your advertisement platform.</li>
 <li>DFP - if using the DoubleClick for Publishers advertisement platform.</li>
 <li>CodeFund - if using the CodeFund ethical advertisement platform.</li>
+<li>Carbon Ads - if using the Carbon Ads advertisement platform.</li>
 </ul>
 </ul>
 
@@ -92,6 +94,10 @@ Only for Product Link and Banner Ads.
 ##### CodeFund Embed Tag to Discourse's Site Settings
 
 ![CodeFund Instructions](https://s3-us-west-2.amazonaws.com/codesponsor/discourse-codefund-instructions.png)
+
+##### Carbon Ads Script Tag to Discourse's Site Settings
+
+![Carbon Ads](https://kodular-community.s3.dualstack.eu-west-1.amazonaws.com/original/3X/3/a/3acc7488db2b53733cdd427d3cb1b76361c786e1.png)
 
 ### Step 3 - See Your Ad
 

--- a/assets/javascripts/discourse/components/carbonads-ad.js.es6
+++ b/assets/javascripts/discourse/components/carbonads-ad.js.es6
@@ -14,17 +14,20 @@ export default Ember.Component.extend({
     this._super();
   },
 
+  @computed("serve_id", "placement")
   url: function() {
     return (`//cdn.carbonads.com/carbon.js?serve=${this.get("serve_id")}&placement=${this.get("placement")}`).htmlSafe();
-  }.property("serve_id", "placement"),
+  },
 
+
+  @computed("trust_level")
   checkTrustLevels: function() {
     return !(
       currentUser &&
       currentUser.get("trust_level") >
         Discourse.SiteSettings.carbonads_through_trust_level
     );
-  }.property("trust_level"),
+  },
 
   @computed("checkTrustLevels")
   showAd: function(checkTrustLevels) {

--- a/assets/javascripts/discourse/components/carbonads-ad.js.es6
+++ b/assets/javascripts/discourse/components/carbonads-ad.js.es6
@@ -3,7 +3,7 @@ import {
   observes
 } from "ember-addons/ember-computed-decorators";
 
-var currentUser = Discourse.User.current(),
+const currentUser = Discourse.User.current(),
   serve_id = Discourse.SiteSettings.carbonads_serve_id,
   placement = Discourse.SiteSettings.carbonads_placement;
 

--- a/assets/javascripts/discourse/components/carbonads-ad.js.es6
+++ b/assets/javascripts/discourse/components/carbonads-ad.js.es6
@@ -1,0 +1,33 @@
+import {
+  default as computed,
+  observes
+} from "ember-addons/ember-computed-decorators";
+
+var currentUser = Discourse.User.current(),
+  serve_id = Discourse.SiteSettings.carbonads_serve_id,
+  placement = Discourse.SiteSettings.carbonads_placement;
+
+export default Ember.Component.extend({
+  init: function() {
+    this.set("serve_id", serve_id);
+    this.set("placement", placement);
+    this._super();
+  },
+
+  url: function() {
+    return (`//cdn.carbonads.com/carbon.js?serve=${this.get("serve_id")}&placement=${this.get("placement")}`).htmlSafe();
+  }.property("serve_id", "placement"),
+
+  checkTrustLevels: function() {
+    return !(
+      currentUser &&
+      currentUser.get("trust_level") >
+        Discourse.SiteSettings.carbonads_through_trust_level
+    );
+  }.property("trust_level"),
+
+  @computed("checkTrustLevels")
+  showAd: function(checkTrustLevels) {
+    return placement && serve_id && checkTrustLevels;
+  }
+});

--- a/assets/javascripts/discourse/templates/components/carbonads-ad.hbs
+++ b/assets/javascripts/discourse/templates/components/carbonads-ad.hbs
@@ -1,0 +1,4 @@
+{{#if showAd}}
+  <script src={{url}} id="_carbonads_js" async type="text/javascript">
+  </script>
+{{/if}}

--- a/assets/javascripts/discourse/templates/connectors/discovery-list-container-top/discourse-adplugin.hbs
+++ b/assets/javascripts/discourse/templates/connectors/discovery-list-container-top/discourse-adplugin.hbs
@@ -11,6 +11,9 @@
   {{#if siteSettings.codefund_top_of_topic_list_enabled}}
     {{codefund-ad placement="topic-list-top" listLoading=listLoading refreshOnChange=listLoading}}
   {{/if}}
+  {{#if siteSettings.carbonads_topic_list_top_enabled}}
+    {{carbonads-ad}}
+  {{/if}}
 {{else}}
   {{#if siteSettings.adsense_topic_list_top_code}}
     {{google-adsense placement="topic-list-top" listLoading=listLoading}}
@@ -23,5 +26,8 @@
   {{/if}}
   {{#if siteSettings.codefund_top_of_topic_list_enabled}}
     {{codefund-ad placement="topic-list-top" listLoading=listLoading refreshOnChange=listLoading}}
+  {{/if}}
+  {{#if siteSettings.carbonads_topic_list_top_enabled}}
+    {{carbonads-ad}}
   {{/if}}
 {{/if}}

--- a/assets/javascripts/discourse/templates/connectors/topic-above-post-stream/discourse-adplugin.hbs
+++ b/assets/javascripts/discourse/templates/connectors/topic-above-post-stream/discourse-adplugin.hbs
@@ -11,6 +11,9 @@
   {{#if siteSettings.codefund_above_post_stream_enabled}}
     {{codefund-ad placement="topic-above-post-stream"}}
   {{/if}}
+  {{#if siteSettings.carbonads_above_post_stream_enabled}}
+    {{carbonads-ad}}
+  {{/if}}
 {{else}}
   {{#if siteSettings.adsense_topic_above_post_stream_code}}
     {{google-adsense placement="topic-above-post-stream"}}
@@ -23,5 +26,8 @@
   {{/if}}
   {{#if siteSettings.codefund_above_post_stream_enabled}}
     {{codefund-ad placement="topic-above-post-stream"}}
+  {{/if}}
+  {{#if siteSettings.carbonads_above_post_stream_enabled}}
+    {{carbonads-ad}}
   {{/if}}
 {{/if}}

--- a/assets/stylesheets/adplugin.scss
+++ b/assets/stylesheets/adplugin.scss
@@ -176,3 +176,49 @@ and (max-width : 775px) {
   height: 1px;
   width: 1px;
 }
+
+#carbonads {
+  display: block;
+  overflow: hidden;
+  padding: 1em;
+  border: 1px solid #ccc;
+  font-family: Verdana, "Helvetica Neue", Helvetica, sans-serif;
+  line-height: 1.5;
+  margin-bottom: 15px;
+}
+
+#carbonads span {
+  position: relative;
+  display: block;
+  overflow: hidden;
+}
+
+.carbon-img {
+  float: left;
+  margin-right: 1em;
+}
+
+.carbon-img img {
+  display: block;
+  line-height: 1;
+}
+
+.carbon-text {
+  display: block;
+  float: left;
+  max-width: calc(100% - 130px - 1em);
+  text-align: left;
+  color: dark-light-choose($primary-medium, $secondary-medium);
+}
+
+.carbon-poweredby {
+  position: absolute;
+  right: 0; // You can also set the position to the "left" with the value of calc(130px + carbon-text’s font size). If the font-size is 12px, you’ll want to set the left value as 142px. It’ll align the .carbon-text with .carbon-poweredby
+  bottom: 0;
+  display: block;
+  font-size: .8em;
+  text-transform: uppercase;
+  line-height: 1;
+  letter-spacing: 1px;
+  color: $quaternary !important;
+}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -10,3 +10,4 @@ en:
           adsense_plugin: 'AdSense'
           amazon_plugin: 'Amazon'
           codefund_plugin: 'CodeFund'
+          carbonads_plugin: 'Carbon Ads'

--- a/config/locales/client.es.yml
+++ b/config/locales/client.es.yml
@@ -17,3 +17,4 @@ es:
           adsense_plugin: 'AdSense'
           amazon_plugin: 'Amazon'
           codefund_plugin: 'CodeFund'
+          carbonads_plugin: 'Carbon Ads'

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -90,3 +90,9 @@ en:
     codefund_above_post_stream_enabled: "Show an ad above the post stream"
     codefund_above_suggested_enabled: "Show an ad above the suggested topic list"
     codefund_top_of_topic_list_enabled: "Show an ad above the topic list"
+
+    carbonads_serve_id: "Your Carbon Ads Serve ID"
+    carbonads_placement: "Your Carbon Ads Placement"
+    carbonads_through_trust_level: "Show your ads to users based on trust levels. Users with trust level higher than this value will not see ads."
+    carbonads_topic_list_top_enabled: "Show an ad above the topic list"
+    carbonads_above_post_stream_enabled: "Show an ad above the post stream"

--- a/config/locales/server.es.yml
+++ b/config/locales/server.es.yml
@@ -90,3 +90,9 @@ es:
     codefund_above_post_stream_enabled: "Mostrar un anuncio encima de las publicaciones"
     codefund_above_suggested_enabled: "Mostrar un anuncio encima de la lista de temas sugeridos"
     codefund_top_of_topic_list_enabled: "Mostrar un anuncio encima de la lista de temas"
+
+    carbonads_serve_id: "Tu identificador \"serve\" de Carbon Ads"
+    carbonads_placement: "Tu identificador \"placement\" de Carbon Ads"
+    carbonads_through_trust_level: "Muestre sus anuncios a los usuarios según los niveles de confianza. Los usuarios con un nivel de confianza superior a este valor no verán los anuncios."
+    carbonads_topic_list_top_enabled: "Mostrar un anuncio encima de la lista de temas"
+    carbonads_above_post_stream_enabled: "Mostrar un anuncio encima de las publicaciones"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -379,3 +379,21 @@ codefund_plugin:
   codefund_top_of_topic_list_enabled:
     default: true
     client: true
+
+carbonads_plugin:
+  carbonads_serve_id:
+    client: true
+    default: ""
+  carbonads_placement:
+    client: true
+    default: ""
+  carbonads_through_trust_level:
+    client: true
+    default: 2
+    enum: "TrustLevelSetting"
+  carbonads_topic_list_top_enabled:
+    client: true
+    default: false
+  carbonads_above_post_stream_enabled:
+    client: true
+    default: false

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,6 +1,6 @@
 # name: discourse-adplugin
 # about: Ad Plugin for Discourse
-# version: 1.0.2
+# version: 1.1.0
 # authors: Vi and Sarah (@ladydanger and @cyberkoi)
 # url: https://github.com/discourse/discourse-adplugin
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -21,17 +21,4 @@ after_initialize do
   Discourse::Application.routes.append do
     get '/ads.txt' => "adstxt#index"
   end
-
-  if !SiteSetting.content_security_policy_script_src.split('|'.freeze).include?("http://cdn.carbonads.com")
-    SiteSetting.content_security_policy_script_src = SiteSetting.content_security_policy_script_src+'|http://cdn.carbonads.com'
-  end
-  if !SiteSetting.content_security_policy_script_src.split('|'.freeze).include?("https://cdn.carbonads.com")
-    SiteSetting.content_security_policy_script_src = SiteSetting.content_security_policy_script_src+'|https://cdn.carbonads.com'
-  end
-  if !SiteSetting.content_security_policy_script_src.split('|'.freeze).include?("http://srv.carbonads.net")
-    SiteSetting.content_security_policy_script_src = SiteSetting.content_security_policy_script_src+'|http://srv.carbonads.net'
-  end
-  if !SiteSetting.content_security_policy_script_src.split('|'.freeze).include?("https://srv.carbonads.net")
-    SiteSetting.content_security_policy_script_src = SiteSetting.content_security_policy_script_src+'|https://srv.carbonads.net'
-  end
 end

--- a/plugin.rb
+++ b/plugin.rb
@@ -21,4 +21,17 @@ after_initialize do
   Discourse::Application.routes.append do
     get '/ads.txt' => "adstxt#index"
   end
+
+  if !SiteSetting.content_security_policy_script_src.split('|'.freeze).include?("http://cdn.carbonads.com")
+    SiteSetting.content_security_policy_script_src = SiteSetting.content_security_policy_script_src+'|http://cdn.carbonads.com'
+  end
+  if !SiteSetting.content_security_policy_script_src.split('|'.freeze).include?("https://cdn.carbonads.com")
+    SiteSetting.content_security_policy_script_src = SiteSetting.content_security_policy_script_src+'|https://cdn.carbonads.com'
+  end
+  if !SiteSetting.content_security_policy_script_src.split('|'.freeze).include?("http://srv.carbonads.net")
+    SiteSetting.content_security_policy_script_src = SiteSetting.content_security_policy_script_src+'|http://srv.carbonads.net'
+  end
+  if !SiteSetting.content_security_policy_script_src.split('|'.freeze).include?("https://srv.carbonads.net")
+    SiteSetting.content_security_policy_script_src = SiteSetting.content_security_policy_script_src+'|https://srv.carbonads.net'
+  end
 end


### PR DESCRIPTION
This PR adds Carbon Ads support to Discourse-AdPlugin  

```
CARBON ADS GUIDELINES
There can be only one ad per page.
The ad should be visible above-the-fold (upper 800 pixels) for desktop browser.
The ad should be visible within 3x of the mobile viewport height, starting from the top of the mobile browser.
The ad tag should be placed exactly where you'd like the ad to display.
The ad image must remain 130 × 100 pixels, unmodified and unobscured.
The ad text is up to 80 characters in length and must be clearly visible.
```

To comply with this, there are only two possible locations for the ad: above topic lists and above posts stream.

---

![image](https://user-images.githubusercontent.com/19251112/55683310-85413b80-593e-11e9-97d9-1ca9d9b2ab68.png)

![image](https://user-images.githubusercontent.com/19251112/55683265-28de1c00-593e-11e9-8e7c-4edc1fe0e7da.png)
![image](https://user-images.githubusercontent.com/19251112/55683269-2f6c9380-593e-11e9-9b19-a95de94aa4be.png)
![image](https://user-images.githubusercontent.com/19251112/55683274-34c9de00-593e-11e9-8d30-53df666506ca.png)
