### PR TITLE
DEV: migrate no_ads_for_groups to use IDs instead of group names

### DIFF
--- a/assets/javascripts/discourse/components/ad-component.js.es6
+++ b/assets/javascripts/discourse/components/ad-component.js.es6
@@ -46,12 +46,21 @@ export default Ember.Component.extend({
       return true;
     }
 
-    const groupNames = groups.map(g => g.name.toLowerCase());
-    const noAdsGroupNames = this.siteSettings.no_ads_for_groups
-      .split("|")
-      .map(g => g.toLowerCase());
+    let noAdsGroups = this.siteSettings.no_ads_for_groups
+        .split("|")
 
-    return !groupNames.any(g => noAdsGroupNames.includes(g));
+    // TODO: Remove when 2.4 becomes the new stable. This is for backwards compatibility.
+    const groupListUseIDs = this.site.group_list_use_ids;
+
+    let currentGroups = groups;
+    if (groupListUseIDs) {
+      currentGroups = currentGroups.map(g => g.id.toString());
+    } else {
+      currentGroups = currentGroups.map(g => g.name.toLowerCase());
+      noAdsGroups = noAdsGroups.map(g => g.toLowerCase());
+    }
+
+    return !currentGroups.any(g => noAdsGroups.includes(g));
   },
 
   @computed(

--- a/plugin.rb
+++ b/plugin.rb
@@ -35,6 +35,11 @@ after_initialize do
   require_dependency File.expand_path('../app/controllers/house_ad_settings_controller', __FILE__)
   require_dependency 'application_controller'
 
+  # TODO: remove when 2.4 becomes the new stable
+  current_version = ActiveRecord::Migrator.current_version
+  min_version = 201_907_081_533_31
+  add_to_serializer(:site, :group_list_use_ids) { current_version >= min_version }
+
   add_to_serializer :site, :house_creatives do
     AdPlugin::HouseAdSetting.settings_and_ads
   end


### PR DESCRIPTION
This PR depends on https://github.com/discourse/discourse/pull/7860 which changes the way `group_list` site settings are stored, storing IDs instead of group names. 

To maintain backwards compatibility, we also ship:

- A way to migrate the setting values **only** after being sure the core's code is available.
- A way to keep the feature working when we still have group names instead of IDs

