### PR TITLE
DEV: migrate no_ads_for_groups to use IDs instead of group names [Undo revert]

### DIFF
--- a/assets/javascripts/discourse/components/ad-component.js.es6
+++ b/assets/javascripts/discourse/components/ad-component.js.es6
@@ -46,12 +46,20 @@ export default Ember.Component.extend({
       return true;
     }
 
-    const groupNames = groups.map(g => g.name.toLowerCase());
-    const noAdsGroupNames = this.siteSettings.no_ads_for_groups
-      .split("|")
-      .map(g => g.toLowerCase());
+    let noAdsGroups = this.siteSettings.no_ads_for_groups.split("|");
 
-    return !groupNames.any(g => noAdsGroupNames.includes(g));
+    // TODO: Remove when 2.4 becomes the new stable. This is for backwards compatibility.
+    const groupListUseIDs = this.site.group_list_use_ids;
+
+    let currentGroups = groups;
+    if (groupListUseIDs) {
+      currentGroups = currentGroups.map(g => g.id.toString());
+    } else {
+      currentGroups = currentGroups.map(g => g.name.toLowerCase());
+      noAdsGroups = noAdsGroups.map(g => g.toLowerCase());
+    }
+
+    return !currentGroups.any(g => noAdsGroups.includes(g));
   },
 
   @computed(

--- a/plugin.rb
+++ b/plugin.rb
@@ -28,12 +28,21 @@ module ::AdPlugin
   end
 end
 
+# TODO: Remove this once 2.4.0.beta3 is released.
+# HACK: Checking if the file exists, this means we can assume the migration happenned
+above_min_version = File.exist?(
+  File.expand_path('../../../db/migrate/20190717133743_migrate_group_list_site_settings.rb', __FILE__)
+)
+
 after_initialize do
   require_dependency File.expand_path('../app/models/house_ad', __FILE__)
   require_dependency File.expand_path('../app/models/house_ad_setting', __FILE__)
   require_dependency File.expand_path('../app/controllers/house_ads_controller', __FILE__)
   require_dependency File.expand_path('../app/controllers/house_ad_settings_controller', __FILE__)
   require_dependency 'application_controller'
+
+  # TODO: remove when 2.4 becomes the new stable
+  add_to_serializer(:site, :group_list_use_ids) { above_min_version }
 
   add_to_serializer :site, :house_creatives do
     AdPlugin::HouseAdSetting.settings_and_ads


### PR DESCRIPTION
This reverts commit dee02ac3ba3a080d59084fd26011b945c615ca55.