### PR TITLE
FIX:  removes part of the 2.4 legacy code forgotten

### DIFF
--- a/assets/javascripts/discourse/components/ad-component.js.es6
+++ b/assets/javascripts/discourse/components/ad-component.js.es6
@@ -51,19 +51,10 @@ export default Ember.Component.extend({
       return true;
     }
 
-    let noAdsGroups = this.siteSettings.no_ads_for_groups.split("|");
-
-    // TODO: Remove when 2.4 becomes the new stable. This is for backwards compatibility.
-    const groupListUseIDs = this.site.group_list_use_ids;
-
-    let currentGroups = groups;
-    if (groupListUseIDs) {
-      currentGroups = currentGroups.map(g => g.id.toString());
-    } else {
-      currentGroups = currentGroups.map(g => g.name.toLowerCase());
-      noAdsGroups = noAdsGroups.map(g => g.toLowerCase());
-    }
-
+    let noAdsGroups = this.siteSettings.no_ads_for_groups
+      .split("|")
+      .filter(Boolean);
+    let currentGroups = groups.map(g => g.id.toString());
     return !currentGroups.any(g => noAdsGroups.includes(g));
   },
 


### PR DESCRIPTION
no_ads_for_groups returns a list of ids