### PR TITLE
FIX: re-revert db4f5f99 with updated tests

### DIFF
--- a/assets/javascripts/discourse/components/ad-component.js.es6
+++ b/assets/javascripts/discourse/components/ad-component.js.es6
@@ -51,18 +51,10 @@ export default Ember.Component.extend({
       return true;
     }
 
-    let noAdsGroups = this.siteSettings.no_ads_for_groups.split("|");
-
-    // TODO: Remove when 2.4 becomes the new stable. This is for backwards compatibility.
-    const groupListUseIDs = this.site.group_list_use_ids;
-
-    let currentGroups = groups;
-    if (groupListUseIDs) {
-      currentGroups = currentGroups.map(g => g.id.toString());
-    } else {
-      currentGroups = currentGroups.map(g => g.name.toLowerCase());
-      noAdsGroups = noAdsGroups.map(g => g.toLowerCase());
-    }
+    let noAdsGroups = this.siteSettings.no_ads_for_groups
+      .split("|")
+      .filter(Boolean);
+    let currentGroups = groups.map(g => g.id.toString());
 
     return !currentGroups.any(g => noAdsGroups.includes(g));
   },

--- a/test/javascripts/acceptance/adsense-test.js.es6
+++ b/test/javascripts/acceptance/adsense-test.js.es6
@@ -4,7 +4,7 @@ import groupFixtures from "fixtures/group-fixtures";
 acceptance("AdSense", {
   loggedIn: true,
   settings: {
-    no_ads_for_groups: "discourse",
+    no_ads_for_groups: "47",
     no_ads_for_categories: "1",
     adsense_publisher_code: "MYADSENSEID",
     adsense_through_trust_level: 2,

--- a/test/javascripts/acceptance/dfp-test.js.es6
+++ b/test/javascripts/acceptance/dfp-test.js.es6
@@ -4,7 +4,7 @@ import groupFixtures from "fixtures/group-fixtures";
 acceptance("DFP Ads", {
   loggedIn: true,
   settings: {
-    no_ads_for_groups: "discourse",
+    no_ads_for_groups: "47",
     no_ads_for_categories: "1",
     dfp_publisher_id: "MYdfpID",
     dfp_through_trust_level: 2,


### PR DESCRIPTION
The tests were using an incorrect value for the site setting (the name of the group instead of the id).

`no_ads_for_groups` shows groups names in the UI byt actually stores IDs.