### PR TITLE
Add support for adsense fluid format for in-feed

### DIFF
--- a/assets/javascripts/discourse/components/google-adsense.js.es6
+++ b/assets/javascripts/discourse/components/google-adsense.js.es6
@@ -11,6 +11,9 @@ function parseAdWidth(value) {
   if (value === "responsive") {
     return "auto";
   }
+  if (value.startsWith("fluid")) {
+    return "fluid";
+  }
   const w = parseInt(value.substring(0, 3).trim(), 10);
   if (isNaN(w)) {
     return "auto";
@@ -22,6 +25,9 @@ function parseAdWidth(value) {
 function parseAdHeight(value) {
   if (value === "responsive") {
     return "auto";
+  }
+  if (value.startsWith("fluid")) {
+    return "fluid";
   }
   const h = parseInt(value.substring(4, 7).trim(), 10);
   if (isNaN(h)) {
@@ -172,7 +178,12 @@ export default AdComponent.extend({
 
   @discourseComputed("ad_width")
   isResponsive(adWidth) {
-    return adWidth === "auto";
+    return ["auto", "fluid"].includes(adWidth);
+  },
+
+  @discourseComputed("ad_width")
+  isFluid(adWidth) {
+    return adWidth === "fluid";
   },
 
   @discourseComputed("placement", "showAd")
@@ -182,7 +193,7 @@ export default AdComponent.extend({
 
   @discourseComputed("isResponsive")
   autoAdFormat(isResponsive) {
-    return isResponsive ? "auto".htmlSafe() : false;
+    return isResponsive ? (isFluid ? "fluid".htmlSafe() : "auto".htmlSafe()) : false;
   },
 
   @discourseComputed("ad_width", "ad_height", "isResponsive")

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -55,6 +55,7 @@ adsense_plugin:
     type: list
     choices: &adsense_choices
       - responsive
+      - fluid - for in-feed ad units
       - 728*90 - leaderboard
       - 336*280 - large rectangle
       - 300*250 - medium rectangle


### PR DESCRIPTION
Hey there, I was having trouble getting in-feed ads to work (I haven't tested with in-article ads so I can't say if it applies to those too) in AdSense, and from what I found by testing manually it looks like the key was the `data-ad-format="fluid"` attribute of the `<ins />`.

This adds an override for "fluid" format while hopefully keeping the same functionality for "auto".