### PR TITLE
DEV: Remove 'htmlSafe' string prototype extensions

### DIFF
--- a/assets/javascripts/discourse/components/amazon-product-links.js
+++ b/assets/javascripts/discourse/components/amazon-product-links.js
@@ -1,6 +1,7 @@
 import AdComponent from "discourse/plugins/discourse-adplugin/discourse/components/ad-component";
 import discourseComputed from "discourse-common/utils/decorators";
 import { and } from "@ember/object/computed";
+import { htmlSafe } from "@ember/template";
 
 export default AdComponent.extend({
   classNames: ["amazon-product-links"],
@@ -157,27 +158,27 @@ export default AdComponent.extend({
 
   @discourseComputed("amazon_width", "amazon_height")
   adWrapperStyle(w, h) {
-    return `width: ${w}px; height: ${h}px;`.htmlSafe();
+    return htmlSafe(`width: ${w}px; height: ${h}px;`);
   },
 
   @discourseComputed("mobile_amazon_width", "mobile_amazon_height")
   adWrapperStyleMobile(w, h) {
-    return `width: ${w}px; height: ${h}px;`.htmlSafe();
+    return htmlSafe(`width: ${w}px; height: ${h}px;`);
   },
 
   @discourseComputed("mobile_amazon_width")
   adTitleStyleMobile(w) {
-    return `width: ${w}px;`.htmlSafe();
+    return htmlSafe(`width: ${w}px;`);
   },
 
   @discourseComputed("user_input")
   userInput(userInput) {
-    return `${userInput}`.htmlSafe();
+    return htmlSafe(`${userInput}`);
   },
 
   @discourseComputed("user_input_mobile")
   userInputMobile(userInput) {
-    return `${userInput}`.htmlSafe();
+    return htmlSafe(`${userInput}`);
   },
 
   @discourseComputed("currentUser.trust_level")

--- a/assets/javascripts/discourse/components/carbonads-ad.js
+++ b/assets/javascripts/discourse/components/carbonads-ad.js
@@ -1,5 +1,6 @@
 import AdComponent from "discourse/plugins/discourse-adplugin/discourse/components/ad-component";
 import discourseComputed from "discourse-common/utils/decorators";
+import { htmlSafe } from "@ember/template";
 
 export default AdComponent.extend({
   serve_id: null,
@@ -13,7 +14,9 @@ export default AdComponent.extend({
 
   @discourseComputed("serve_id", "placement")
   url(serveId, placement) {
-    return `//cdn.carbonads.com/carbon.js?serve=${serveId}&placement=${placement}`.htmlSafe();
+    return htmlSafe(
+      `//cdn.carbonads.com/carbon.js?serve=${serveId}&placement=${placement}`
+    );
   },
 
   @discourseComputed("currentUser.trust_level")

--- a/assets/javascripts/discourse/components/google-adsense.js
+++ b/assets/javascripts/discourse/components/google-adsense.js
@@ -4,6 +4,7 @@ import loadScript from "discourse/lib/load-script";
 import RSVP from "rsvp";
 import { scheduleOnce } from "@ember/runloop";
 import { isTesting } from "discourse-common/config/environment";
+import { htmlSafe } from "@ember/template";
 
 let _loaded = false,
   _promise = null,
@@ -191,28 +192,24 @@ export default AdComponent.extend({
 
   @discourseComputed("placement", "showAd")
   classForSlot(placement, showAd) {
-    return showAd ? `adsense-${placement}`.htmlSafe() : "";
+    return showAd ? htmlSafe(`adsense-${placement}`) : "";
   },
 
   @discourseComputed("isResponsive", "isFluid")
   autoAdFormat(isResponsive, isFluid) {
-    return isResponsive
-      ? isFluid
-        ? "fluid".htmlSafe()
-        : "auto".htmlSafe()
-      : false;
+    return isResponsive ? htmlSafe(isFluid ? "fluid" : "auto") : false;
   },
 
   @discourseComputed("ad_width", "ad_height", "isResponsive")
   adWrapperStyle(w, h, isResponsive) {
-    return (isResponsive ? "" : `width: ${w}; height: ${h};`).htmlSafe();
+    return htmlSafe(isResponsive ? "" : `width: ${w}; height: ${h};`);
   },
 
   @discourseComputed("adWrapperStyle", "isResponsive")
   adInsStyle(adWrapperStyle, isResponsive) {
-    return `display: ${
-      isResponsive ? "block" : "inline-block"
-    }; ${adWrapperStyle}`.htmlSafe();
+    return htmlSafe(
+      `display: ${isResponsive ? "block" : "inline-block"}; ${adWrapperStyle}`
+    );
   },
 
   @discourseComputed("currentUser.trust_level")

--- a/assets/javascripts/discourse/components/google-dfp-ad.js
+++ b/assets/javascripts/discourse/components/google-dfp-ad.js
@@ -4,6 +4,7 @@ import loadScript from "discourse/lib/load-script";
 import { alias } from "@ember/object/computed";
 import RSVP from "rsvp";
 import { isTesting } from "discourse-common/config/environment";
+import { htmlSafe } from "@ember/template";
 
 let _loaded = false,
   _promise = null,
@@ -286,14 +287,14 @@ export default AdComponent.extend({
   @discourseComputed("width", "height")
   adWrapperStyle(w, h) {
     if (w !== "fluid") {
-      return `width: ${w}px; height: ${h}px;`.htmlSafe();
+      return htmlSafe(`width: ${w}px; height: ${h}px;`);
     }
   },
 
   @discourseComputed("width")
   adTitleStyleMobile(w) {
     if (w !== "fluid") {
-      return `width: ${w}px;`.htmlSafe();
+      return htmlSafe(`width: ${w}px;`);
     }
   },
 


### PR DESCRIPTION
## Ember Upgrade

Context: https://deprecations.emberjs.com/v3.x/#toc_ember-string-prototype_extensions