### PR TITLE
UX: introduce min-height for responsive ads

### DIFF
--- a/assets/javascripts/discourse/templates/components/google-adsense.hbs
+++ b/assets/javascripts/discourse/templates/components/google-adsense.hbs
@@ -2,7 +2,11 @@
   <div class="google-adsense-label"><h2>{{i18n
         "adplugin.advertisement_label"
       }}</h2></div>
-  <div class="google-adsense-content" style={{adWrapperStyle}}>
+  <div
+    class="google-adsense-content"
+    id={{if isResponsive "google-adsense__responsive"}}
+    style={{adWrapperStyle}}
+  >
     <ins
       class="adsbygoogle"
       style={{adInsStyle}}

--- a/assets/stylesheets/adplugin.scss
+++ b/assets/stylesheets/adplugin.scss
@@ -18,6 +18,12 @@
   width: 100%;
 }
 
+#google-adsense__responsive {
+  // Google strips styles added to parent wrapper classes, so we use this ID
+  // this sets a minimum height to reduce content layout shift
+  min-height: 200px;
+}
+
 .google-adsense .google-adsense-label {
   width: 728px;
   max-width: 100%;

--- a/assets/stylesheets/adplugin.scss
+++ b/assets/stylesheets/adplugin.scss
@@ -20,7 +20,7 @@
 
 #google-adsense__responsive {
   // Google strips styles added to parent wrapper classes, so we use this ID
-  // this sets a minimum height to reduce content layout shift
+  // this sets a minimum height to reduce cumulative layout shift
   min-height: 200px;
 }
 


### PR DESCRIPTION
We've had reports that google is complaining about cumulative layout shift when responsive ads are enabled. This adds a minimum height to responsive ad unit containers to avoid the shift that occurs when an ad loads. 

This works in my test environment, but we'll have to keep an eye on whether or not this introduces too much extra space if an ad doesn't load for whatever reason. 

📖 /t/82520