### PR TITLE
DEV: Abort placing adsense if Ember component is destroyed

### DIFF
--- a/assets/javascripts/discourse/components/google-adsense.js
+++ b/assets/javascripts/discourse/components/google-adsense.js
@@ -141,22 +141,27 @@ export default AdComponent.extend({
     this._super();
   },
 
-  _triggerAds() {
+  async _triggerAds() {
     if (isTesting()) {
       return; // Don't load external JS during tests
     }
 
     this.set("adRequested", true);
-    loadAdsense().then(function () {
-      const adsbygoogle = window.adsbygoogle || [];
 
-      try {
-        adsbygoogle.push({}); // ask AdSense to fill one ad unit
-      } catch (ex) {
-        // eslint-disable-next-line no-console
-        console.error("Adsense error:", ex);
-      }
-    });
+    await loadAdsense();
+
+    if (this.isDestroyed || this.isDestroying) {
+      // Component removed from DOM before script loaded
+      return;
+    }
+
+    try {
+      const adsbygoogle = (window.adsbygoogle ||= []);
+      adsbygoogle.push({}); // ask AdSense to fill one ad unit
+    } catch (ex) {
+      // eslint-disable-next-line no-console
+      console.error("Adsense error:", ex);
+    }
   },
 
   didInsertElement() {


### PR DESCRIPTION
This should avoid surprising error messages being printed to the console