### PR TITLE
DEV: Pass `post` instead of `transformedPost` to post-bottom-ad

### DIFF
--- a/assets/javascripts/discourse/connectors/post-bottom/discourse-adplugin.hbs
+++ b/assets/javascripts/discourse/connectors/post-bottom/discourse-adplugin.hbs
@@ -1,1 +1,0 @@
-{{post-bottom-ad model=this}}

--- a/assets/javascripts/discourse/initializers/initialize-ad-plugin.js
+++ b/assets/javascripts/discourse/initializers/initialize-ad-plugin.js
@@ -14,7 +14,7 @@ export default {
 
     withPluginApi("0.1", (api) => {
       api.decorateWidget("post:after", (helper) => {
-        return helper.attach("after-post-ad", helper.attrs);
+        return helper.attach("after-post-ad", helper.widget.model);
       });
     });
 


### PR DESCRIPTION
Changes in 0948d6b19e34320f95226cc43fbce976b71ceb31 caused the post-bottom-ad component to start receiving the widget-ised 'transformedPost' instead of the original `post` model. In most cases this difference didn't matter, but it did cause noticable issues with `@model.category` and `@model.topic`.

This commit also deletes the unused `post-bottom/discourse-adplugin.hbs` connector. In the past, the adplugin itself was defining the post-bottom outlet. But now, we use RenderGlimmer to load the `post-bottom-ad` directly.