### PR TITLE
FEATURE: Improve DFP / Ad-manager Content-Security-Policy compat

### DIFF
--- a/assets/javascripts/discourse/components/google-dfp-ad.js
+++ b/assets/javascripts/discourse/components/google-dfp-ad.js
@@ -229,6 +229,9 @@ function loadGoogle() {
       // we always use refresh() to fetch the ads:
       window.googletag.pubads().disableInitialLoad();
 
+      // Improve CSP compatibility (https://developers.google.com/publisher-tag/guides/content-security-policy)
+      window.googletag.pubads().setForceSafeFrame(true);
+
       window.googletag.enableServices();
     });
   });


### PR DESCRIPTION
Switching to cross-domain iframes is recommended by google here: https://developers.google.com/publisher-tag/guides/content-security-policy