### PR TITLE
DEV: Update more deprecated Font Awesome icon names

### DIFF
--- a/admin/assets/javascripts/discourse/components/house-ads-list-setting.hbs
+++ b/admin/assets/javascripts/discourse/components/house-ads-list-setting.hbs
@@ -7,7 +7,7 @@
 <div class="setting-controls">
   {{#if this.changed}}
     <DButton class="ok" @action={{action "save"}} @icon="check" />
-    <DButton class="cancel" @action={{action "cancel"}} @icon="times" />
+    <DButton class="cancel" @action={{action "cancel"}} @icon="xmark" />
   {{/if}}
 </div>
 <p class="help">{{this.help}}</p>

--- a/admin/assets/javascripts/discourse/components/house-ads-setting.hbs
+++ b/admin/assets/javascripts/discourse/components/house-ads-setting.hbs
@@ -3,7 +3,7 @@
 <div class="setting-controls">
   {{#if this.changed}}
     <DButton class="ok" @action={{action "save"}} @icon="check" />
-    <DButton class="cancel" @action={{action "cancel"}} @icon="times" />
+    <DButton class="cancel" @action={{action "cancel"}} @icon="xmark" />
   {{/if}}
 </div>
 <p class="help">{{this.help}}</p>

--- a/admin/assets/javascripts/discourse/templates/admin/plugins-house-ads-index.hbs
+++ b/admin/assets/javascripts/discourse/templates/admin/plugins-house-ads-index.hbs
@@ -36,7 +36,7 @@
 
       <DButton
         @label="admin.adplugin.house_ads.more_settings"
-        @icon="cog"
+        @icon="gear"
         @action={{route-action "moreSettings"}}
         class="btn-default"
       />


### PR DESCRIPTION
This PR updates more deprecated Font Awesome icon names. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.