### PR TITLE
FIX: HouseAdsChooser `onChange` handling

### DIFF
--- a/admin/assets/javascripts/discourse/components/house-ads-chooser.js
+++ b/admin/assets/javascripts/discourse/components/house-ads-chooser.js
@@ -22,11 +22,6 @@ export default class HouseAdsChooser extends MultiSelectComponent {
       .filter(Boolean);
   }
 
-  // TODO: kept for legacy, remove when Discourse is 2.5
-  mutateValues(values) {
-    this.set("settingValue", values.join(this.tokenSeparator));
-  }
-
   computeValues() {
     return this.settingValue.split(this.tokenSeparator).filter(Boolean);
   }
@@ -34,11 +29,5 @@ export default class HouseAdsChooser extends MultiSelectComponent {
   @computed("choices")
   get content() {
     return makeArray(this.choices);
-  }
-
-  @action
-  onChange(value) {
-    const settingValue = makeArray(value).join(this.tokenSeparator);
-    this.onChange?.(settingValue);
   }
 }

--- a/admin/assets/javascripts/discourse/components/house-ads-list-setting.hbs
+++ b/admin/assets/javascripts/discourse/components/house-ads-list-setting.hbs
@@ -2,7 +2,7 @@
 {{house-ads-chooser
   settingValue=this.adValue
   choices=this.adNames
-  onChange=(action (mut this.adValue))
+  onChange=this.changeAdValue
 }}
 <div class="setting-controls">
   {{#if this.changed}}

--- a/admin/assets/javascripts/discourse/components/house-ads-list-setting.js
+++ b/admin/assets/javascripts/discourse/components/house-ads-list-setting.js
@@ -1,8 +1,16 @@
+import { action } from "@ember/object";
 import { mapBy } from "@ember/object/computed";
 import { classNames } from "@ember-decorators/component";
+import { makeArray } from "discourse-common/lib/helpers";
 import HouseAdsSetting from "discourse/plugins/discourse-adplugin/discourse/components/house-ads-setting";
 
 @classNames("house-ads-setting house-ads-list-setting")
 export default class HouseAdsListSetting extends HouseAdsSetting {
   @mapBy("allAds", "name") adNames;
+
+  @action
+  changeAdValue(value) {
+    const settingValue = makeArray(value).join("|");
+    this.set("adValue", settingValue);
+  }
 }


### PR DESCRIPTION
Having an action named the same as an argument is no longer possible in a classic component. Move the logic to the parent instead.

Followup to 7685ebf396c93e8accc5a76a81fcec4384a73fa3