### PR TITLE
DEV: Add compatibility with the Glimmer Post Stream

### DIFF
--- a/.discourse-compatibility
+++ b/.discourse-compatibility
@@ -1,3 +1,4 @@
+< 3.5.0.beta8-dev: fcd734079b10644066d07379071b1de057e7a19c
 < 3.5.0.beta5-dev: bd9af0b9a577bfd2c01cc8b81a782a4e8b81b9c5
 < 3.5.0.beta1-dev: 6ceba62e985223c269782c4bc9a1bdc4a5adba28
 < 3.4.0.beta2-dev: 7685ebf396c93e8accc5a76a81fcec4384a73fa3

--- a/.discourse-compatibility
+++ b/.discourse-compatibility
@@ -1,4 +1,4 @@
-< 3.5.0.beta8-dev: fcd734079b10644066d07379071b1de057e7a19c
+< 3.5.0.beta8-dev: e51aad3bfd41cf2cb9557e025e833122a9f6c892
 < 3.5.0.beta5-dev: bd9af0b9a577bfd2c01cc8b81a782a4e8b81b9c5
 < 3.5.0.beta1-dev: 6ceba62e985223c269782c4bc9a1bdc4a5adba28
 < 3.4.0.beta2-dev: 7685ebf396c93e8accc5a76a81fcec4384a73fa3

--- a/assets/javascripts/discourse/initializers/initialize-ad-plugin.gjs
+++ b/assets/javascripts/discourse/initializers/initialize-ad-plugin.gjs
@@ -1,14 +1,14 @@
 import { hbs } from "ember-cli-htmlbars";
+import { withSilencedDeprecations } from "discourse/lib/deprecated";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import Site from "discourse/models/site";
 import { registerWidgetShim } from "discourse/widgets/render-glimmer";
-import { withSilencedDeprecations } from "discourse/lib/deprecated";
 import PostBottomAd from "../components/post-bottom-ad";
 
 export default {
   name: "initialize-ad-plugin",
   initialize(container) {
-    withPluginApi("0.1", (api) => {
+    withPluginApi((api) => {
       customizePost(api);
     });
 

--- a/assets/javascripts/discourse/initializers/initialize-ad-plugin.gjs
+++ b/assets/javascripts/discourse/initializers/initialize-ad-plugin.gjs
@@ -28,7 +28,11 @@ export default {
 function customizePost(api) {
   api.renderAfterWrapperOutlet(
     "post-article",
-    <template><PostBottomAd @model={{@post}} /></template>
+    <template>
+      <div class="ad-connector">
+        <PostBottomAd @model={{@post}} />
+      </div>
+    </template>
   );
 
   withSilencedDeprecations("discourse.post-stream-widget-overrides", () =>
@@ -39,7 +43,7 @@ function customizePost(api) {
 function customizeWidgetPost(api) {
   registerWidgetShim(
     "after-post-ad",
-    "div.widget-connector",
+    "div.ad-connector",
     hbs`<PostBottomAd @model={{@data}} />`
   );
 

--- a/test/javascripts/acceptance/adsense-test.js
+++ b/test/javascripts/acceptance/adsense-test.js
@@ -7,101 +7,107 @@ import {
   updateCurrentUser,
 } from "discourse/tests/helpers/qunit-helpers";
 
-acceptance("AdSense", function (needs) {
-  needs.user();
-  needs.settings({
-    no_ads_for_groups: "47",
-    no_ads_for_categories: "1",
-    adsense_publisher_code: "MYADSENSEID",
-    adsense_display_groups: [
-      AUTO_GROUPS.trust_level_1,
-      AUTO_GROUPS.trust_level_2,
-    ],
-    adsense_topic_list_top_code: "list_top_ad_unit",
-    adsense_topic_list_top_ad_sizes: "728*90 - leaderboard",
-    adsense_mobile_topic_list_top_code: "mobile_list_top_ad_unit",
-    adsense_mobile_topic_list_top_ad_size: "300*250 - medium rectangle",
-    adsense_post_bottom_code: "post_bottom_ad_unit",
-    adsense_post_bottom_ad_sizes: "728*90 - leaderboard",
-    adsense_mobile_post_bottom_code: "mobile_post_bottom_ad_unit",
-    adsense_mobile_post_bottom_ad_size: "300*250 - medium rectangle",
-    adsense_nth_post_code: 6,
-    adsense_topic_above_post_stream_code: "above_post_stream_ad_unit",
-    adsense_topic_above_post_stream_ad_sizes: "728*90 - leaderboard",
-  });
-  needs.site({
-    house_creatives: {
-      settings: {
-        topic_list_top: "",
-        topic_above_post_stream: "",
-        topic_above_suggested: "",
-        post_bottom: "",
-        after_nth_post: 20,
-      },
-      creatives: {},
-    },
-  });
+["enabled", "disabled"].forEach((postStreamMode) => {
+  acceptance(
+    `AdSense (glimmer_post_stream_mode = ${postStreamMode})`,
+    function (needs) {
+      needs.user();
+      needs.settings({
+        no_ads_for_groups: "47",
+        no_ads_for_categories: "1",
+        adsense_publisher_code: "MYADSENSEID",
+        adsense_display_groups: [
+          AUTO_GROUPS.trust_level_1,
+          AUTO_GROUPS.trust_level_2,
+        ],
+        adsense_topic_list_top_code: "list_top_ad_unit",
+        adsense_topic_list_top_ad_sizes: "728*90 - leaderboard",
+        adsense_mobile_topic_list_top_code: "mobile_list_top_ad_unit",
+        adsense_mobile_topic_list_top_ad_size: "300*250 - medium rectangle",
+        adsense_post_bottom_code: "post_bottom_ad_unit",
+        adsense_post_bottom_ad_sizes: "728*90 - leaderboard",
+        adsense_mobile_post_bottom_code: "mobile_post_bottom_ad_unit",
+        adsense_mobile_post_bottom_ad_size: "300*250 - medium rectangle",
+        adsense_nth_post_code: 6,
+        adsense_topic_above_post_stream_code: "above_post_stream_ad_unit",
+        adsense_topic_above_post_stream_ad_sizes: "728*90 - leaderboard",
+        glimmer_post_stream_mode: postStreamMode,
+      });
+      needs.site({
+        house_creatives: {
+          settings: {
+            topic_list_top: "",
+            topic_above_post_stream: "",
+            topic_above_suggested: "",
+            post_bottom: "",
+            after_nth_post: 20,
+          },
+          creatives: {},
+        },
+      });
 
-  test("correct number of ads should show", async (assert) => {
-    updateCurrentUser({
-      staff: false,
-      trust_level: 1,
-      groups: [AUTO_GROUPS.trust_level_1],
-      show_adsense_ads: true,
-      show_to_groups: true,
-    });
-    await visit("/t/280"); // 20 posts
+      test("correct number of ads should show", async (assert) => {
+        updateCurrentUser({
+          staff: false,
+          trust_level: 1,
+          groups: [AUTO_GROUPS.trust_level_1],
+          show_adsense_ads: true,
+          show_to_groups: true,
+        });
+        await visit("/t/280"); // 20 posts
 
-    assert
-      .dom(".google-adsense.adsense-topic-above-post-stream")
-      .exists({ count: 1 }, "it should render 1 ad above post stream");
+        assert
+          .dom(".google-adsense.adsense-topic-above-post-stream")
+          .exists({ count: 1 }, "it should render 1 ad above post stream");
 
-    assert
-      .dom(".google-adsense.adsense-post-bottom")
-      .exists({ count: 3 }, "it should render 3 ads");
+        assert
+          .dom(".google-adsense.adsense-post-bottom")
+          .exists({ count: 3 }, "it should render 3 ads");
 
-    assert
-      .dom("#post_6 + .widget-connector .google-adsense.adsense-post-bottom")
-      .exists({ count: 1 }, "ad after 6th post");
+        assert
+          .dom("#post_6 + .ad-connector .google-adsense.adsense-post-bottom")
+          .exists({ count: 1 }, "ad after 6th post");
 
-    assert
-      .dom("#post_12 + .widget-connector .google-adsense.adsense-post-bottom")
-      .exists({ count: 1 }, "ad after 12th post");
+        assert
+          .dom("#post_12 + .ad-connector .google-adsense.adsense-post-bottom")
+          .exists({ count: 1 }, "ad after 12th post");
 
-    assert
-      .dom("#post_18 + .widget-connector .google-adsense.adsense-post-bottom")
-      .exists({ count: 1 }, "ad after 18th post");
-  });
+        assert
+          .dom("#post_18 + .ad-connector .google-adsense.adsense-post-bottom")
+          .exists({ count: 1 }, "ad after 18th post");
+      });
 
-  test("no ads for trust level 3", async (assert) => {
-    updateCurrentUser({
-      staff: false,
-      trust_level: 3,
-      groups: [AUTO_GROUPS.trust_level_3],
-    });
-    await visit("/t/280");
-    assert
-      .dom(".google-adsense.adsense-post-bottom")
-      .doesNotExist("it should render 0 ads");
-  });
+      test("no ads for trust level 3", async (assert) => {
+        updateCurrentUser({
+          staff: false,
+          trust_level: 3,
+          groups: [AUTO_GROUPS.trust_level_3],
+        });
+        await visit("/t/280");
+        assert
+          .dom(".google-adsense.adsense-post-bottom")
+          .doesNotExist("it should render 0 ads");
+      });
 
-  test("can omit ads based on groups", async (assert) => {
-    updateCurrentUser({
-      staff: false,
-      trust_level: 1,
-      groups: [groupFixtures["/groups/discourse.json"].group],
-    });
-    await visit("/t/280");
-    assert
-      .dom(".google-adsense.adsense-post-bottom")
-      .doesNotExist("it should render 0 ads");
-  });
+      test("can omit ads based on groups", async (assert) => {
+        updateCurrentUser({
+          staff: false,
+          trust_level: 1,
+          groups: [groupFixtures["/groups/discourse.json"].group],
+        });
+        await visit("/t/280");
+        assert
+          .dom(".google-adsense.adsense-post-bottom")
+          .doesNotExist("it should render 0 ads");
+      });
 
-  test("can omit ads based on category", async (assert) => {
-    updateCurrentUser({ staff: false, trust_level: 1 });
-    await visit("/t/28830");
-    assert
-      .dom(".google-adsense.adsense-topic-above-post-stream")
-      .doesNotExist("it should render 0 ads");
-  });
+      test("can omit ads based on category", async (assert) => {
+        updateCurrentUser({ staff: false, trust_level: 1 });
+        await visit("/t/28830");
+        assert
+          .dom(".google-adsense.adsense-topic-above-post-stream")
+          .doesNotExist("it should render 0 ads");
+      });
+    }
+  );
 });

--- a/test/javascripts/acceptance/dfp-test.js
+++ b/test/javascripts/acceptance/dfp-test.js
@@ -7,98 +7,107 @@ import {
   updateCurrentUser,
 } from "discourse/tests/helpers/qunit-helpers";
 
-acceptance("DFP Ads", function (needs) {
-  needs.user();
-  needs.settings({
-    no_ads_for_groups: "47",
-    no_ads_for_categories: "1",
-    dfp_publisher_id: "MYdfpID",
-    dfp_through_trust_level: 2,
-    dfp_display_groups: [AUTO_GROUPS.trust_level_1, AUTO_GROUPS.trust_level_2],
-    dfp_topic_list_top_code: "list_top_ad_unit",
-    dfp_topic_list_top_ad_sizes: "728*90 - leaderboard",
-    dfp_mobile_topic_list_top_code: "mobile_list_top_ad_unit",
-    dfp_mobile_topic_list_top_ad_size: "300*250 - medium rectangle",
-    dfp_post_bottom_code: "post_bottom_ad_unit",
-    dfp_post_bottom_ad_sizes: "728*90 - leaderboard",
-    dfp_mobile_post_bottom_code: "mobile_post_bottom_ad_unit",
-    dfp_mobile_post_bottom_ad_size: "300*250 - medium rectangle",
-    dfp_nth_post_code: 6,
-    dfp_topic_above_post_stream_code: "list_top_ad_unit",
-    dfp_topic_above_post_stream_ad_sizes: "728*90 - leaderboard",
-  });
-  needs.site({
-    house_creatives: {
-      settings: {
-        topic_list_top: "",
-        topic_above_post_stream: "",
-        topic_above_suggested: "",
-        post_bottom: "",
-        after_nth_post: 20,
-      },
-      creatives: {},
-    },
-  });
+["enabled", "disabled"].forEach((postStreamMode) => {
+  acceptance(
+    `DFP Ads (glimmer_post_stream_mode = ${postStreamMode})`,
+    function (needs) {
+      needs.user();
+      needs.settings({
+        no_ads_for_groups: "47",
+        no_ads_for_categories: "1",
+        dfp_publisher_id: "MYdfpID",
+        dfp_through_trust_level: 2,
+        dfp_display_groups: [
+          AUTO_GROUPS.trust_level_1,
+          AUTO_GROUPS.trust_level_2,
+        ],
+        dfp_topic_list_top_code: "list_top_ad_unit",
+        dfp_topic_list_top_ad_sizes: "728*90 - leaderboard",
+        dfp_mobile_topic_list_top_code: "mobile_list_top_ad_unit",
+        dfp_mobile_topic_list_top_ad_size: "300*250 - medium rectangle",
+        dfp_post_bottom_code: "post_bottom_ad_unit",
+        dfp_post_bottom_ad_sizes: "728*90 - leaderboard",
+        dfp_mobile_post_bottom_code: "mobile_post_bottom_ad_unit",
+        dfp_mobile_post_bottom_ad_size: "300*250 - medium rectangle",
+        dfp_nth_post_code: 6,
+        dfp_topic_above_post_stream_code: "list_top_ad_unit",
+        dfp_topic_above_post_stream_ad_sizes: "728*90 - leaderboard",
+        glimmer_post_stream_mode: postStreamMode,
+      });
+      needs.site({
+        house_creatives: {
+          settings: {
+            topic_list_top: "",
+            topic_above_post_stream: "",
+            topic_above_suggested: "",
+            post_bottom: "",
+            after_nth_post: 20,
+          },
+          creatives: {},
+        },
+      });
 
-  test("correct number of ads should show", async (assert) => {
-    updateCurrentUser({
-      staff: false,
-      trust_level: 1,
-      show_dfp_ads: true,
-      show_to_groups: true,
-    });
-    await visit("/t/280"); // 20 posts
+      test("correct number of ads should show", async (assert) => {
+        updateCurrentUser({
+          staff: false,
+          trust_level: 1,
+          show_dfp_ads: true,
+          show_to_groups: true,
+        });
+        await visit("/t/280"); // 20 posts
 
-    assert
-      .dom(".google-dfp-ad.dfp-ad-post-bottom")
-      .exists({ count: 3 }, "it should render 3 ads");
+        assert
+          .dom(".google-dfp-ad.dfp-ad-post-bottom")
+          .exists({ count: 3 }, "it should render 3 ads");
 
-    assert
-      .dom("#post_6 + .widget-connector .google-dfp-ad.dfp-ad-post-bottom")
-      .exists({ count: 1 }, "ad after 6th post");
+        assert
+          .dom("#post_6 + .ad-connector .google-dfp-ad.dfp-ad-post-bottom")
+          .exists({ count: 1 }, "ad after 6th post");
 
-    assert
-      .dom("#post_12 + .widget-connector .google-dfp-ad.dfp-ad-post-bottom")
-      .exists({ count: 1 }, "ad after 12th post");
+        assert
+          .dom("#post_12 + .ad-connector .google-dfp-ad.dfp-ad-post-bottom")
+          .exists({ count: 1 }, "ad after 12th post");
 
-    assert
-      .dom("#post_18 + .widget-connector .google-dfp-ad.dfp-ad-post-bottom")
-      .exists({ count: 1 }, "ad after 18th post");
-  });
+        assert
+          .dom("#post_18 + .ad-connector .google-dfp-ad.dfp-ad-post-bottom")
+          .exists({ count: 1 }, "ad after 18th post");
+      });
 
-  test("no ads for trust level 3", async (assert) => {
-    updateCurrentUser({
-      staff: false,
-      trust_level: 3,
-      groups: [
-        AUTO_GROUPS.trust_level_1,
-        AUTO_GROUPS.trust_level_2,
-        AUTO_GROUPS.trust_level_3,
-      ],
-    });
-    await visit("/t/280");
-    assert
-      .dom(".google-dfp-ad.dfp-ad-post-bottom")
-      .doesNotExist("it should render 0 ads");
-  });
+      test("no ads for trust level 3", async (assert) => {
+        updateCurrentUser({
+          staff: false,
+          trust_level: 3,
+          groups: [
+            AUTO_GROUPS.trust_level_1,
+            AUTO_GROUPS.trust_level_2,
+            AUTO_GROUPS.trust_level_3,
+          ],
+        });
+        await visit("/t/280");
+        assert
+          .dom(".google-dfp-ad.dfp-ad-post-bottom")
+          .doesNotExist("it should render 0 ads");
+      });
 
-  test("can omit ads based on groups", async (assert) => {
-    updateCurrentUser({
-      staff: false,
-      trust_level: 1,
-      groups: [groupFixtures["/groups/discourse.json"].group],
-    });
-    await visit("/t/280");
-    assert
-      .dom(".google-dfp-ad.dfp-ad-post-bottom")
-      .doesNotExist("it should render 0 ads");
-  });
+      test("can omit ads based on groups", async (assert) => {
+        updateCurrentUser({
+          staff: false,
+          trust_level: 1,
+          groups: [groupFixtures["/groups/discourse.json"].group],
+        });
+        await visit("/t/280");
+        assert
+          .dom(".google-dfp-ad.dfp-ad-post-bottom")
+          .doesNotExist("it should render 0 ads");
+      });
 
-  test("can omit ads based on category", async (assert) => {
-    updateCurrentUser({ staff: false, trust_level: 1 });
-    await visit("/t/28830");
-    assert
-      .dom(".google-dfp-ad.dfp-ad-topic-above-post-stream")
-      .doesNotExist("it should render 0 ads");
-  });
+      test("can omit ads based on category", async (assert) => {
+        updateCurrentUser({ staff: false, trust_level: 1 });
+        await visit("/t/28830");
+        assert
+          .dom(".google-dfp-ad.dfp-ad-topic-above-post-stream")
+          .doesNotExist("it should render 0 ads");
+      });
+    }
+  );
 });

--- a/test/javascripts/acceptance/house-ad-test.js
+++ b/test/javascripts/acceptance/house-ad-test.js
@@ -6,326 +6,344 @@ import {
   updateCurrentUser,
 } from "discourse/tests/helpers/qunit-helpers";
 
-acceptance("House Ads", function (needs) {
-  needs.user();
-  needs.settings({
-    no_ads_for_categories: "1",
-    house_ads_after_nth_post: 6,
-    house_ads_after_nth_topic: 3,
-  });
-  needs.site({
-    house_creatives: {
-      settings: {
-        topic_list_top: "Topic List Top",
-        topic_above_post_stream: "Above Post Stream",
-        topic_above_suggested: "Above Suggested",
-        post_bottom: "Post",
-        topic_list_between: "Between Topic List",
-        after_nth_post: 6,
-        after_nth_topic: 6,
-      },
-      creatives: {
-        "Topic List Top": {
-          html: "<div class='h-topic-list'>TOPIC LIST TOP</div>",
-          category_ids: [],
+["enabled", "disabled"].forEach((postStreamMode) => {
+  acceptance(
+    `House Ads (glimmer_post_stream_mode = ${postStreamMode})`,
+    function (needs) {
+      needs.user();
+      needs.settings({
+        no_ads_for_categories: "1",
+        house_ads_after_nth_post: 6,
+        house_ads_after_nth_topic: 3,
+        glimmer_post_stream_mode: postStreamMode,
+      });
+      needs.site({
+        house_creatives: {
+          settings: {
+            topic_list_top: "Topic List Top",
+            topic_above_post_stream: "Above Post Stream",
+            topic_above_suggested: "Above Suggested",
+            post_bottom: "Post",
+            topic_list_between: "Between Topic List",
+            after_nth_post: 6,
+            after_nth_topic: 6,
+          },
+          creatives: {
+            "Topic List Top": {
+              html: "<div class='h-topic-list'>TOPIC LIST TOP</div>",
+              category_ids: [],
+            },
+            "Above Post Stream": {
+              html: "<div class='h-above-post-stream'>ABOVE POST STREAM</div>",
+              category_ids: [],
+            },
+            "Above Suggested": {
+              html: "<div class='h-above-suggested'>ABOVE SUGGESTED</div>",
+              category_ids: [],
+            },
+            Post: {
+              html: "<div class='h-post'>BELOW POST</div>",
+              category_ids: [],
+            },
+            "Between Topic List": {
+              html: "<div class='h-between-topic-list'>BETWEEN TOPIC LIST</div>",
+              category_ids: [],
+            },
+          },
         },
-        "Above Post Stream": {
-          html: "<div class='h-above-post-stream'>ABOVE POST STREAM</div>",
-          category_ids: [],
+      });
+
+      test("correct ads show", async (assert) => {
+        updateCurrentUser({
+          staff: false,
+          trust_level: 1,
+          show_to_groups: true,
+        });
+        await visit("/t/280"); // 20 posts
+
+        assert
+          .dom(".h-above-post-stream")
+          .exists({ count: 1 }, "it should render ad at top of topic");
+
+        assert
+          .dom(".h-above-suggested")
+          .exists({ count: 1 }, "it should render ad above suggested topics");
+
+        assert
+          .dom(".h-post")
+          .exists({ count: 3 }, "it should render 3 ads between posts");
+
+        assert
+          .dom("#post_6 + .ad-connector .h-post")
+          .exists({ count: 1 }, "ad after 6th post");
+
+        assert
+          .dom("#post_12 + .ad-connector .h-post")
+          .exists({ count: 1 }, "ad after 12th post");
+
+        assert
+          .dom("#post_18 + .ad-connector .h-post")
+          .exists({ count: 1 }, "ad after 18th post");
+
+        await visit("/latest");
+
+        assert
+          .dom(".h-topic-list")
+          .exists({ count: 1 }, "it should render ad above topic list");
+        const originalTopAdElement = query(".h-topic-list");
+
+        assert
+          .dom(".h-between-topic-list")
+          .exists({ count: 5 }, "it should render 5 ads between topics");
+
+        await visit("/top");
+        const newTopAdElement = query(".h-topic-list");
+
+        assert.notStrictEqual(
+          originalTopAdElement,
+          newTopAdElement,
+          "ad is fully re-rendered when changing pages"
+        );
+
+        await visit("/t/28830");
+
+        assert
+          .dom(".h-above-post-stream")
+          .doesNotExist(
+            "no ad above post stream because category is in no_ads_for_categories"
+          );
+
+        assert
+          .dom(".h-post")
+          .doesNotExist(
+            "no ad between posts because category is in no_ads_for_categories"
+          );
+
+        assert
+          .dom(".h-above-suggested")
+          .doesNotExist(
+            "no ad above suggested because category is in no_ads_for_categories"
+          );
+
+        await visit("/c/bug");
+
+        assert
+          .dom(".h-topic-list")
+          .doesNotExist(
+            "no ad above category topic list because category is in no_ads_for_categories"
+          );
+      });
+    }
+  );
+
+  acceptance(
+    `House Ads | Category and Group Permissions | Authenticated | Display Ad (glimmer_post_stream_mode = ${postStreamMode})`,
+    function (needs) {
+      needs.user();
+      needs.settings({
+        no_ads_for_categories: "",
+        glimmer_post_stream_mode: postStreamMode,
+      });
+      needs.site({
+        house_creatives: {
+          settings: {
+            topic_list_top: "Topic List Top",
+          },
+          creatives: {
+            "Topic List Top": {
+              html: "<div class='h-topic-list'>TOPIC LIST TOP</div>",
+              // match /c/bug/1
+              category_ids: [1],
+            },
+          },
         },
-        "Above Suggested": {
-          html: "<div class='h-above-suggested'>ABOVE SUGGESTED</div>",
-          category_ids: [],
+      });
+
+      test("displays ad to users when current category id is included in ad category_ids", async (assert) => {
+        updateCurrentUser({
+          staff: false,
+          trust_level: 1,
+          show_to_groups: true,
+        });
+        await visit("/c/bug/1");
+        assert
+          .dom(".h-topic-list")
+          .exists(
+            "ad is displayed above the topic list because the current category id is included in the ad category_ids"
+          );
+      });
+    }
+  );
+
+  acceptance(
+    `House Ads | Category and Group Permissions | Authenticated | Hide Ad (glimmer_post_stream_mode = ${postStreamMode})`,
+    function (needs) {
+      needs.user();
+      needs.settings({
+        no_ads_for_categories: "",
+        glimmer_post_stream_mode: postStreamMode,
+      });
+      needs.site({
+        house_creatives: {
+          settings: {
+            topic_list_top: "Topic List Top",
+          },
+          creatives: {
+            "Topic List Top": {
+              html: "<div class='h-topic-list'>TOPIC LIST TOP</div>",
+              // restrict ad to a different category than /c/bug/1
+              category_ids: [2],
+            },
+          },
         },
-        Post: {
-          html: "<div class='h-post'>BELOW POST</div>",
-          category_ids: [],
+      });
+
+      test("hides ad to users when current category id is not included in ad category_ids", async (assert) => {
+        updateCurrentUser({
+          staff: false,
+          trust_level: 1,
+          show_to_groups: true,
+        });
+        await visit("/c/bug/1");
+        assert
+          .dom(".h-topic-list")
+          .doesNotExist(
+            "ad is not displayed because the current category id is not included in the ad category_ids"
+          );
+      });
+    }
+  );
+
+  acceptance(
+    `House Ads | Category and Group Permissions | Anonymous | Hide Ad (glimmer_post_stream_mode = ${postStreamMode})`,
+    function (needs) {
+      needs.settings({
+        no_ads_for_categories: "",
+        glimmer_post_stream_mode: postStreamMode,
+      });
+      needs.site({
+        house_creatives: {
+          settings: {
+            topic_list_top: "Topic List Top",
+          },
+          creatives: {
+            "Topic List Top": {
+              html: "<div class='h-topic-list'>TOPIC LIST TOP</div>",
+              // restrict ad to a different category than /c/bug/1
+              category_ids: [2],
+            },
+          },
         },
-        "Between Topic List": {
-          html: "<div class='h-between-topic-list'>BETWEEN TOPIC LIST</div>",
-          category_ids: [],
+      });
+
+      test("hides ad to anon users when current category id is not included in ad category_ids", async (assert) => {
+        await visit("/c/bug/1");
+        assert
+          .dom(".h-topic-list")
+          .doesNotExist(
+            "ad is not displayed because the current category id is not included in the ad category_ids"
+          );
+      });
+    }
+  );
+
+  acceptance(
+    `House Ads | Category and Group Permissions | Anonymous | Hide Ad (glimmer_post_stream_mode = ${postStreamMode})`,
+    function (needs) {
+      needs.settings({
+        no_ads_for_categories: "",
+        glimmer_post_stream_mode: postStreamMode,
+      });
+      needs.site({
+        house_creatives: {
+          settings: {
+            topic_list_top: "Topic List Top",
+          },
+          creatives: {
+            "Topic List Top": {
+              html: "<div class='h-topic-list'>TOPIC LIST TOP</div>",
+              // restrict ad to a different category than /c/bug/1
+              category_ids: [2],
+            },
+          },
         },
-      },
-    },
-  });
+      });
 
-  test("correct ads show", async (assert) => {
-    updateCurrentUser({ staff: false, trust_level: 1, show_to_groups: true });
-    await visit("/t/280"); // 20 posts
+      test("hides ad to anon users when current category id is not included in ad category_ids", async (assert) => {
+        await visit("/c/bug/1");
+        assert
+          .dom(".h-topic-list")
+          .doesNotExist(
+            "ad is not displayed because the current category id is not included in the ad category_ids"
+          );
+      });
+    }
+  );
 
-    assert
-      .dom(".h-above-post-stream")
-      .exists({ count: 1 }, "it should render ad at top of topic");
+  acceptance(
+    `House Ads | Category and Group Permissions | Anonymous | Show Ad (glimmer_post_stream_mode = ${postStreamMode})`,
+    function (needs) {
+      needs.settings({
+        no_ads_for_categories: "",
+        glimmer_post_stream_mode: postStreamMode,
+      });
+      needs.site({
+        house_creatives: {
+          settings: {
+            topic_list_top: "Topic List Top",
+          },
+          creatives: {
+            "Topic List Top": {
+              html: "<div class='h-topic-list'>TOPIC LIST TOP</div>",
+              // match /c/bug/1
+              category_ids: [1],
+            },
+          },
+        },
+      });
 
-    assert
-      .dom(".h-above-suggested")
-      .exists({ count: 1 }, "it should render ad above suggested topics");
+      test("shows ad to anon users when current category id is included in ad category_ids", async (assert) => {
+        await visit("/c/bug/1");
+        assert
+          .dom(".h-topic-list")
+          .exists(
+            "ad is displayed because the current category id is included in the ad category_ids"
+          );
+      });
+    }
+  );
 
-    assert
-      .dom(".h-post")
-      .exists({ count: 3 }, "it should render 3 ads between posts");
+  acceptance(
+    `House Ads | Category and Group Permissions | Anonymous | Show non-restricted ads (glimmer_post_stream_mode = ${postStreamMode})`,
+    function (needs) {
+      needs.settings({
+        no_ads_for_categories: "",
+        glimmer_post_stream_mode: postStreamMode,
+      });
+      needs.site({
+        house_creatives: {
+          settings: {
+            topic_list_top: "Topic List Top One|Topic List Top Two",
+          },
+          creatives: {
+            "Topic List Top One": {
+              html: "<div class='h-topic-list-one'>TOPIC LIST TOP ONE</div>",
+              category_ids: [2],
+            },
+            "Topic List Top Two": {
+              html: "<div class='h-topic-list-two'>TOPIC LIST TOP TWO</div>",
+              category_ids: [],
+            },
+          },
+        },
+      });
 
-    assert
-      .dom("#post_6 + .widget-connector .h-post")
-      .exists({ count: 1 }, "ad after 6th post");
-
-    assert
-      .dom("#post_12 + .widget-connector .h-post")
-      .exists({ count: 1 }, "ad after 12th post");
-
-    assert
-      .dom("#post_18 + .widget-connector .h-post")
-      .exists({ count: 1 }, "ad after 18th post");
-
-    await visit("/latest");
-
-    assert
-      .dom(".h-topic-list")
-      .exists({ count: 1 }, "it should render ad above topic list");
-    const originalTopAdElement = query(".h-topic-list");
-
-    assert
-      .dom(".h-between-topic-list")
-      .exists({ count: 5 }, "it should render 5 ads between topics");
-
-    await visit("/top");
-    const newTopAdElement = query(".h-topic-list");
-
-    assert.notStrictEqual(
-      originalTopAdElement,
-      newTopAdElement,
-      "ad is fully re-rendered when changing pages"
-    );
-
-    await visit("/t/28830");
-
-    assert
-      .dom(".h-above-post-stream")
-      .doesNotExist(
-        "no ad above post stream because category is in no_ads_for_categories"
-      );
-
-    assert
-      .dom(".h-post")
-      .doesNotExist(
-        "no ad between posts because category is in no_ads_for_categories"
-      );
-
-    assert
-      .dom(".h-above-suggested")
-      .doesNotExist(
-        "no ad above suggested because category is in no_ads_for_categories"
-      );
-
-    await visit("/c/bug");
-
-    assert
-      .dom(".h-topic-list")
-      .doesNotExist(
-        "no ad above category topic list because category is in no_ads_for_categories"
-      );
-  });
+      test("shows non-restricted ad to anon users", async (assert) => {
+        await visit("/c/bug/1");
+        assert
+          .dom(".h-topic-list-two")
+          .exists("non-restricted ad is displayed");
+      });
+    }
+  );
 });
-
-acceptance(
-  "House Ads | Category and Group Permissions | Authenticated | Display Ad",
-  function (needs) {
-    needs.user();
-    needs.settings({
-      no_ads_for_categories: "",
-    });
-    needs.site({
-      house_creatives: {
-        settings: {
-          topic_list_top: "Topic List Top",
-        },
-        creatives: {
-          "Topic List Top": {
-            html: "<div class='h-topic-list'>TOPIC LIST TOP</div>",
-            // match /c/bug/1
-            category_ids: [1],
-          },
-        },
-      },
-    });
-
-    test("displays ad to users when current category id is included in ad category_ids", async (assert) => {
-      updateCurrentUser({
-        staff: false,
-        trust_level: 1,
-        show_to_groups: true,
-      });
-      await visit("/c/bug/1");
-      assert
-        .dom(".h-topic-list")
-        .exists(
-          "ad is displayed above the topic list because the current category id is included in the ad category_ids"
-        );
-    });
-  }
-);
-
-acceptance(
-  "House Ads | Category and Group Permissions | Authenticated | Hide Ad",
-  function (needs) {
-    needs.user();
-    needs.settings({
-      no_ads_for_categories: "",
-    });
-    needs.site({
-      house_creatives: {
-        settings: {
-          topic_list_top: "Topic List Top",
-        },
-        creatives: {
-          "Topic List Top": {
-            html: "<div class='h-topic-list'>TOPIC LIST TOP</div>",
-            // restrict ad to a different category than /c/bug/1
-            category_ids: [2],
-          },
-        },
-      },
-    });
-
-    test("hides ad to users when current category id is not included in ad category_ids", async (assert) => {
-      updateCurrentUser({
-        staff: false,
-        trust_level: 1,
-        show_to_groups: true,
-      });
-      await visit("/c/bug/1");
-      assert
-        .dom(".h-topic-list")
-        .doesNotExist(
-          "ad is not displayed because the current category id is not included in the ad category_ids"
-        );
-    });
-  }
-);
-
-acceptance(
-  "House Ads | Category and Group Permissions | Anonymous | Hide Ad",
-  function (needs) {
-    needs.settings({
-      no_ads_for_categories: "",
-    });
-    needs.site({
-      house_creatives: {
-        settings: {
-          topic_list_top: "Topic List Top",
-        },
-        creatives: {
-          "Topic List Top": {
-            html: "<div class='h-topic-list'>TOPIC LIST TOP</div>",
-            // restrict ad to a different category than /c/bug/1
-            category_ids: [2],
-          },
-        },
-      },
-    });
-
-    test("hides ad to anon users when current category id is not included in ad category_ids", async (assert) => {
-      await visit("/c/bug/1");
-      assert
-        .dom(".h-topic-list")
-        .doesNotExist(
-          "ad is not displayed because the current category id is not included in the ad category_ids"
-        );
-    });
-  }
-);
-
-acceptance(
-  "House Ads | Category and Group Permissions | Anonymous | Hide Ad",
-  function (needs) {
-    needs.settings({
-      no_ads_for_categories: "",
-    });
-    needs.site({
-      house_creatives: {
-        settings: {
-          topic_list_top: "Topic List Top",
-        },
-        creatives: {
-          "Topic List Top": {
-            html: "<div class='h-topic-list'>TOPIC LIST TOP</div>",
-            // restrict ad to a different category than /c/bug/1
-            category_ids: [2],
-          },
-        },
-      },
-    });
-
-    test("hides ad to anon users when current category id is not included in ad category_ids", async (assert) => {
-      await visit("/c/bug/1");
-      assert
-        .dom(".h-topic-list")
-        .doesNotExist(
-          "ad is not displayed because the current category id is not included in the ad category_ids"
-        );
-    });
-  }
-);
-
-acceptance(
-  "House Ads | Category and Group Permissions | Anonymous | Show Ad",
-  function (needs) {
-    needs.settings({
-      no_ads_for_categories: "",
-    });
-    needs.site({
-      house_creatives: {
-        settings: {
-          topic_list_top: "Topic List Top",
-        },
-        creatives: {
-          "Topic List Top": {
-            html: "<div class='h-topic-list'>TOPIC LIST TOP</div>",
-            // match /c/bug/1
-            category_ids: [1],
-          },
-        },
-      },
-    });
-
-    test("shows ad to anon users when current category id is included in ad category_ids", async (assert) => {
-      await visit("/c/bug/1");
-      assert
-        .dom(".h-topic-list")
-        .exists(
-          "ad is displayed because the current category id is included in the ad category_ids"
-        );
-    });
-  }
-);
-
-acceptance(
-  "House Ads | Category and Group Permissions | Anonymous | Show non-restricted ads",
-  function (needs) {
-    needs.settings({
-      no_ads_for_categories: "",
-    });
-    needs.site({
-      house_creatives: {
-        settings: {
-          topic_list_top: "Topic List Top One|Topic List Top Two",
-        },
-        creatives: {
-          "Topic List Top One": {
-            html: "<div class='h-topic-list-one'>TOPIC LIST TOP ONE</div>",
-            category_ids: [2],
-          },
-          "Topic List Top Two": {
-            html: "<div class='h-topic-list-two'>TOPIC LIST TOP TWO</div>",
-            category_ids: [],
-          },
-        },
-      },
-    });
-
-    test("shows non-restricted ad to anon users", async (assert) => {
-      await visit("/c/bug/1");
-      assert.dom(".h-topic-list-two").exists("non-restricted ad is displayed");
-    });
-  }
-);


### PR DESCRIPTION
This PR updates the ad plugin to support the Glimmer Post Stream and refactors ad rendering logic for improved compatibility and maintainability.

Key changes:

- Introduce glimmer_post_stream_mode compatibility across all ad types and test suites.
- Replace .widget-connector with .ad-connector for ad placement after posts.
- Migrate initialize-ad-plugin.js to initialize-ad-plugin.gjs to leverage Glimmer and API improvements.
- Use withSilencedDeprecations to handle widget overrides for post ads.
- Update compatibility constraints in .discourse-compatibility.
- Refactor and expand acceptance tests for AdSense, DFP, and House Ads to run with both Glimmer and legacy post stream modes.